### PR TITLE
Fix styling issue with curve polygons

### DIFF
--- a/examples/curve-polygon.js
+++ b/examples/curve-polygon.js
@@ -65,7 +65,7 @@ features[1].setStyle(
     }),
     stroke: new Stroke({
       color: '#FF0000',
-      width: 1,
+      width: 4,
     }),
   })
 );

--- a/examples/curve-polygon.js
+++ b/examples/curve-polygon.js
@@ -1,6 +1,7 @@
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 import WKB from '../src/ol/format/WKB.js';
+import {Fill, Stroke, Style} from '../src/ol/style.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 
@@ -44,6 +45,30 @@ const features = wkb.map((wkb) => {
     featureProjection: 'EPSG:3857',
   });
 });
+
+features[0].setStyle(
+  new Style({
+    fill: new Fill({
+      color: '#FF0000',
+    }),
+    stroke: new Stroke({
+      color: '#0000FF',
+      width: 1,
+    }),
+  })
+);
+
+features[1].setStyle(
+  new Style({
+    fill: new Fill({
+      color: '#0000FF',
+    }),
+    stroke: new Stroke({
+      color: '#FF0000',
+      width: 1,
+    }),
+  })
+);
 
 const vector = new VectorLayer({
   source: new VectorSource({

--- a/examples/polygon.html
+++ b/examples/polygon.html
@@ -1,0 +1,9 @@
+---
+layout: example.html
+title: Polygon
+shortdesc: Example of a simple map with two polygons.
+docs: >
+  A simple map with two polygons with different styles.
+tags: "polygon, styles"
+---
+<div id="map" class="map"></div>

--- a/examples/polygon.js
+++ b/examples/polygon.js
@@ -1,0 +1,89 @@
+import GeoJSON from '../src/ol/format/GeoJSON.js';
+import Map from '../src/ol/Map.js';
+import VectorLayer from '../src/ol/layer/Vector.js';
+import VectorSource from '../src/ol/source/Vector.js';
+import View from '../src/ol/View.js';
+import {Fill, Stroke, Style} from '../src/ol/style.js';
+
+const blue = new Style({
+  stroke: new Stroke({
+    color: 'blue',
+    width: 3,
+  }),
+  fill: new Fill({
+    color: 'rgba(0, 0, 255, 1)',
+  }),
+});
+
+const red = new Style({
+  stroke: new Stroke({
+    color: 'red',
+    width: 3,
+  }),
+  fill: new Fill({
+    color: 'rgba(255, 0, 0, 1)',
+  }),
+});
+
+const geojsonObject = {
+  'type': 'FeatureCollection',
+  'crs': {
+    'type': 'name',
+    'properties': {
+      'name': 'EPSG:3857',
+    },
+  },
+  'features': [
+    {
+      'type': 'Feature',
+      'geometry': {
+        'type': 'Polygon',
+        'coordinates': [
+          [
+            [-5e6, 6e6],
+            [-5e6, 8e6],
+            [-3e6, 8e6],
+            [-3e6, 6e6],
+            [-5e6, 6e6],
+          ],
+        ],
+      },
+    },
+    {
+      'type': 'Feature',
+      'geometry': {
+        'type': 'Polygon',
+        'coordinates': [
+          [
+            [-2e6, 6e6],
+            [-2e6, 8e6],
+            [0, 8e6],
+            [0, 6e6],
+            [-2e6, 6e6],
+          ],
+        ],
+      },
+    },
+  ],
+};
+
+const source = new VectorSource({
+  features: new GeoJSON().readFeatures(geojsonObject),
+});
+
+const features = source.getFeatures();
+features[0].setStyle(red);
+features[1].setStyle(blue);
+
+const layer = new VectorLayer({
+  source: source,
+});
+
+const map = new Map({
+  layers: [layer],
+  target: 'map',
+  view: new View({
+    center: [0, 3000000],
+    zoom: 2,
+  }),
+});

--- a/src/ol/render/canvas/CurveBuilder.js
+++ b/src/ol/render/canvas/CurveBuilder.js
@@ -76,6 +76,7 @@ class CanvasCurveBuilder extends CanvasBuilder {
     }
     this.setFillStrokeStyles();
     this.beginGeometry(curvePolygonGeometry, feature);
+    this.instructions.push(beginPathInstruction);
     this.appendCurvePolygonInstructions(curvePolygonGeometry);
     this.endGeometry(feature);
   }
@@ -270,7 +271,6 @@ class CanvasCurveBuilder extends CanvasBuilder {
     }
     state.lastStroke = 0;
     super.applyStroke(state);
-    this.instructions.push(beginPathInstruction);
   }
 }
 


### PR DESCRIPTION
De volgorde van instructies klopt nog steeds niet 100% met die van de normale polygon (de tweede stroke instructie mist bij de curve polygon). Ik heb getest of het stroken met verschillende kleuren en diktes dan misschien niet goed gaat, maar dat is geen probleem! Dus voor nu ljikt het me prima zo, en ga ik daar verder geen tijd in stoppen.

Van de compound curve en circular string dacht ik in de eerste instantie ook dat ze gebruik maakte van die functie die ik heb verplaatst (`this.instructions.push(beginPathInstruction`), maar als ik die ook aan de functies `drawCompoundCurve` en `drawCircularString` toevoeg, dan tekent 'ie alleen nog maar de laatste geometrie. Alle voorbeelden lijken zo als ik het nu heb gedaan in ieder geval goed te werken. :)

 